### PR TITLE
Introduce API for Avatars

### DIFF
--- a/api/db.js
+++ b/api/db.js
@@ -59,6 +59,17 @@ export const CHARACTER = Object.freeze({
 	DELETED: Symbol("deleted"),
 });
 
+// Added for Avatar
+// Only utilizing columns believed to be "safe"
+// Should be reviewed at a later date
+export const AVATAR = Object.freeze({
+	THIS: Symbol("experience"),
+	ID: Symbol("id"),
+	NAME: Symbol("name"),
+	BEP: Symbol("bep"),
+	CEP: Symbol("cep"),
+});
+
 export const LOGIN = Object.freeze({
 	THIS: Symbol("login"),
 	ID: Symbol("id"),
@@ -286,6 +297,22 @@ export async function get_characters(pagination, sort, order) {
 
 		pagination.item_count = char_count;
 		pagination.page_count = Math.ceil(pagination.item_count / pagination.items_per_page);
+
+		return chars.rows;
+	} catch (e) {
+		if (e.code)
+			e.code = pg_error_inv[e.code]
+		throw e;
+	}
+}
+
+// Database action added for the sake of reporting avatar information out to a publicly exposed API route for leader-boards and other components.
+export async function get_character_batch_for_stats(batch, sort, order) {
+	const values = [batch];
+
+	try {
+		const char_count = await get_row_count(CHARACTER.THIS);
+		const chars = await pool.query(`SELECT id, name, faction_id, bep, cep FROM avatar ORDER BY ${to_sql(sort)} ${to_sql(order)} OFFSET $1*1000 LIMIT 1000`, values);
 
 		return chars.rows;
 	} catch (e) {

--- a/api/index.js
+++ b/api/index.js
@@ -5,6 +5,7 @@ import api_auth from './authentication.js'
 import api_user from './user.js'
 import api_info from './info.js'
 import api_admin from './admin.js'
+import api_stats from './stats.js'
 
 const VERSION = JSON.parse(fs.readFileSync('package.json', 'utf8')).version;
 const api = express.Router();
@@ -23,6 +24,7 @@ api.use(bodyParser.urlencoded({ extended: true }));
 
 api.use(api_auth)
 api.use(api_info)
+api.use(api_stats)
 
 // These calls are gated within their respective routers
 api.use(api_user)

--- a/api/stats.js
+++ b/api/stats.js
@@ -1,0 +1,61 @@
+import express from 'express'
+import * as db from './db.js'
+import {AVATAR, SQL_ORDER} from "./db.js";
+
+const api = express.Router();
+
+api.get('/char_stats/:batch', async (req, res, next) => {
+    try {
+        const stats = await db.get_stats();
+
+        stats.empires = { "TR": 0, "NC": 0, "VS": 0 }
+
+        var batch = req.params.batch;
+
+        const avatars = await db.get_character_batch_for_stats(batch, AVATAR.ID, SQL_ORDER.ASCENDING);
+
+        res.status(200).json({ players: avatars });
+
+    } catch (e) {
+        console.log(e);
+        res.status(500).json({ message: 'error' });
+    }
+});
+
+api.get('/char_stats_bep/:batch', async (req, res, next) => {
+    try {
+        const stats = await db.get_stats();
+
+        stats.empires = { "TR": 0, "NC": 0, "VS": 0 }
+
+        var batch = req.params.batch;
+
+        const avatars = await db.get_character_batch_for_stats(batch, AVATAR.BEP, SQL_ORDER.DESCENDING);
+
+        res.status(200).json({ players: avatars });
+
+    } catch (e) {
+        console.log(e);
+        res.status(500).json({ message: 'error' });
+    }
+});
+
+api.get('/char_stats_cep/:batch', async (req, res, next) => {
+    try {
+        const stats = await db.get_stats();
+
+        stats.empires = { "TR": 0, "NC": 0, "VS": 0 }
+
+        var batch = req.params.batch;
+
+        const avatars = await db.get_character_batch_for_stats(batch, AVATAR.CEP, SQL_ORDER.DESCENDING);
+
+        res.status(200).json({ players: avatars });
+
+    } catch (e) {
+        console.log(e);
+        res.status(500).json({ message: 'error' });
+    }
+});
+
+export default api;


### PR DESCRIPTION
API routes for the community to utilize without compromising account details.

Routes include:

- /api/char_stats/**[batch number]**
  - Pulls characters in batches of 1000 and in the order of the ID.
  - Batch # starts from 0
- /api/char_stats_bep/**[batch number]**
  - Pulls characters in batches of 1000 and in the order of the descending order of BEP.
  - Batch # starts from 0
- /api/char_stats_cep/**[batch number]**
  - Pulls characters in batches of 1000 and in the order of the descending order of CEP.
  - Batch # starts from 0

Proposal to keep in mind for the community to utilize on the main PSForever server to track ongoing stats and even deltas from weekend to weekend and in the future, day to day.