### PR TITLE
Fix order of dates

### DIFF
--- a/api/db.js
+++ b/api/db.js
@@ -384,7 +384,7 @@ export async function get_avatar_kd_byDate(id) {
         ' SUM(CASE WHEN victim_id = $1 THEN 1 ELSE 0 END)::int AS deaths' +
         ' FROM killactivity GROUP BY date HAVING' +
         ' SUM(CASE WHEN killer_id = $1 THEN 1 ELSE 0 END) > 0 OR SUM(CASE WHEN victim_id = $1 THEN 1 ELSE 0 END) > 0' +
-        ' ORDER BY date DESC', [id])
+        ' ORDER BY MIN(timestamp) DESC', [id])
 		return kd.rows;
 	} catch (e) {
 		if (e.code)


### PR DESCRIPTION
Manually changed timestamps in database to confirm api call has the dates in order now
![image](https://github.com/psforever/PSFPortal/assets/73139382/0b40f427-7cbf-407d-aecd-456d2b09ce41)
